### PR TITLE
Ensure GA4 status requires property and credentials

### DIFF
--- a/web/src/app/api/integrations/status/route.test.ts
+++ b/web/src/app/api/integrations/status/route.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import type { IntegrationsEnv } from '../../../../integrations/env';
+import type { StoredSecrets } from '../../../../integrations/secrets';
+
+import { computeIntegrationsStatus } from './route';
+
+describe('computeIntegrationsStatus', () => {
+  const baseEnv: IntegrationsEnv = {};
+  const baseHas = { ga4: false, openai: false } as const;
+  const baseSecrets: StoredSecrets = {};
+
+  it('returns ga4=false when property id lacks credentials', () => {
+    const result = computeIntegrationsStatus({
+      env: baseEnv,
+      has: baseHas,
+      secrets: { ...baseSecrets, GA4_PROPERTY_ID: 'prop' },
+    });
+
+    expect(result.ga4).toBe(false);
+  });
+
+  it('returns ga4=true when service account credentials exist', () => {
+    const result = computeIntegrationsStatus({
+      env: baseEnv,
+      has: baseHas,
+      secrets: {
+        ...baseSecrets,
+        GA4_PROPERTY_ID: 'prop',
+        GOOGLE_APPLICATION_CREDENTIALS_JSON: '{"type":"service_account"}',
+      },
+    });
+
+    expect(result.ga4).toBe(true);
+  });
+
+  it('merges env + secrets credentials for OAuth flow', () => {
+    const result = computeIntegrationsStatus({
+      env: {
+        ...baseEnv,
+        GA4_PROPERTY_ID: 'env-prop',
+        GA_OAUTH_CLIENT_SECRET: 'secret',
+      },
+      has: baseHas,
+      secrets: {
+        ...baseSecrets,
+        GA_OAUTH_CLIENT_ID: 'client',
+        GA_OAUTH_REFRESH_TOKEN: 'refresh',
+      },
+    });
+
+    expect(result.ga4).toBe(true);
+  });
+
+  it('considers OpenAI availability from has/openai or secrets', () => {
+    const fromHas = computeIntegrationsStatus({
+      env: baseEnv,
+      has: { ...baseHas, openai: true },
+      secrets: baseSecrets,
+    });
+    expect(fromHas.openai).toBe(true);
+
+    const fromSecrets = computeIntegrationsStatus({
+      env: baseEnv,
+      has: baseHas,
+      secrets: { ...baseSecrets, OPENAI_API_KEY: 'sk-xxx' },
+    });
+    expect(fromSecrets.openai).toBe(true);
+  });
+});

--- a/web/src/app/api/integrations/status/route.ts
+++ b/web/src/app/api/integrations/status/route.ts
@@ -1,21 +1,50 @@
 import { NextResponse } from 'next/server';
-import { integrations } from '@/integrations';
-import { loadSecrets } from '@/integrations/secrets';
+import { integrations, type IntegrationsFacade } from '@/integrations';
+import { hasGA4Config, type IntegrationsEnv } from '@/integrations/env';
+import { loadSecrets, type StoredSecrets } from '@/integrations/secrets';
+
+type ComputeIntegrationsStatusInput = {
+  env: IntegrationsEnv;
+  has: IntegrationsFacade['has'];
+  secrets: StoredSecrets;
+};
+
+export function computeIntegrationsStatus({
+  env,
+  has,
+  secrets,
+}: ComputeIntegrationsStatusInput) {
+  const combinedGa4Config = {
+    GA4_PROPERTY_ID: secrets.GA4_PROPERTY_ID ?? env.GA4_PROPERTY_ID,
+    GOOGLE_APPLICATION_CREDENTIALS_JSON:
+      secrets.GOOGLE_APPLICATION_CREDENTIALS_JSON ??
+      env.GOOGLE_APPLICATION_CREDENTIALS_JSON,
+    GA_OAUTH_CLIENT_ID: secrets.GA_OAUTH_CLIENT_ID ?? env.GA_OAUTH_CLIENT_ID,
+    GA_OAUTH_CLIENT_SECRET:
+      secrets.GA_OAUTH_CLIENT_SECRET ?? env.GA_OAUTH_CLIENT_SECRET,
+    GA_OAUTH_REFRESH_TOKEN:
+      secrets.GA_OAUTH_REFRESH_TOKEN ?? env.GA_OAUTH_REFRESH_TOKEN,
+  } satisfies Parameters<typeof hasGA4Config>[0];
+
+  const ga4Present = hasGA4Config(combinedGa4Config);
+  const openaiPresent = Boolean(has.openai || secrets.OPENAI_API_KEY);
+
+  return {
+    ga4: ga4Present,
+    openai: openaiPresent,
+  } as const;
+}
 
 export async function GET() {
   // Não expõe segredos; apenas flags de disponibilidade
   const secrets = loadSecrets();
-  const ga4Present = Boolean(
-    integrations.has.ga4 || secrets.GA4_PROPERTY_ID
-  );
-  const openaiPresent = Boolean(
-    integrations.has.openai || secrets.OPENAI_API_KEY
-  );
-
-  return NextResponse.json({
-    ga4: ga4Present,
-    openai: openaiPresent,
+  const status = computeIntegrationsStatus({
+    env: integrations.env,
+    has: integrations.has,
+    secrets,
   });
+
+  return NextResponse.json(status);
 }
 
 

--- a/web/src/integrations/env.test.ts
+++ b/web/src/integrations/env.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasGA4Config } from './env';
+
+describe('hasGA4Config', () => {
+  it('returns false when GA4 property id is missing', () => {
+    expect(
+      hasGA4Config({
+        GOOGLE_APPLICATION_CREDENTIALS_JSON: '{}',
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when property id exists without credentials', () => {
+    expect(
+      hasGA4Config({
+        GA4_PROPERTY_ID: 'prop',
+      })
+    ).toBe(false);
+  });
+
+  it('returns true when service account credentials are present', () => {
+    expect(
+      hasGA4Config({
+        GA4_PROPERTY_ID: 'prop',
+        GOOGLE_APPLICATION_CREDENTIALS_JSON: '{"type":"service_account"}',
+      })
+    ).toBe(true);
+  });
+
+  it('returns true when OAuth credentials are present', () => {
+    expect(
+      hasGA4Config({
+        GA4_PROPERTY_ID: 'prop',
+        GA_OAUTH_CLIENT_ID: 'client',
+        GA_OAUTH_CLIENT_SECRET: 'secret',
+        GA_OAUTH_REFRESH_TOKEN: 'refresh',
+      })
+    ).toBe(true);
+  });
+});

--- a/web/src/integrations/env.ts
+++ b/web/src/integrations/env.ts
@@ -35,12 +35,34 @@ export function hasOpenAI(): boolean {
   return Boolean(integrationsEnv.OPENAI_API_KEY);
 }
 
-export function hasGA4(): boolean {
-  return Boolean(
-    integrationsEnv.GA4_PROPERTY_ID &&
-      (integrationsEnv.GOOGLE_APPLICATION_CREDENTIALS_JSON ||
-        (integrationsEnv.GA_OAUTH_CLIENT_ID && integrationsEnv.GA_OAUTH_CLIENT_SECRET && integrationsEnv.GA_OAUTH_REFRESH_TOKEN))
+export type GA4ConfigInput = Partial<
+  Pick<
+    IntegrationsEnv,
+    | 'GA4_PROPERTY_ID'
+    | 'GOOGLE_APPLICATION_CREDENTIALS_JSON'
+    | 'GA_OAUTH_CLIENT_ID'
+    | 'GA_OAUTH_CLIENT_SECRET'
+    | 'GA_OAUTH_REFRESH_TOKEN'
+  >
+>;
+
+export function hasGA4Config(config: GA4ConfigInput): boolean {
+  if (!config.GA4_PROPERTY_ID) {
+    return false;
+  }
+
+  const hasServiceAccount = Boolean(config.GOOGLE_APPLICATION_CREDENTIALS_JSON);
+  const hasOAuthCredentials = Boolean(
+    config.GA_OAUTH_CLIENT_ID &&
+      config.GA_OAUTH_CLIENT_SECRET &&
+      config.GA_OAUTH_REFRESH_TOKEN
   );
+
+  return hasServiceAccount || hasOAuthCredentials;
+}
+
+export function hasGA4(): boolean {
+  return hasGA4Config(integrationsEnv);
 }
 
 

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': new URL('./src', import.meta.url).pathname,
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- reuse the GA4 availability helper so the integrations status endpoint now requires both a property id and either service account or OAuth credentials
- add unit tests that cover the GA4 helper and the status aggregator logic for different credential combinations
- configure Vitest to resolve the `@/` alias used across the web app

## Testing
- npx vitest run src/integrations/env.test.ts src/app/api/integrations/status/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dac85b00ec8329a81a1e116c6711eb