### PR TITLE
Align GA4 integration credentials with GA4 client expectations

### DIFF
--- a/web/docs/ENVIRONMENT_SETUP.md
+++ b/web/docs/ENVIRONMENT_SETUP.md
@@ -103,6 +103,24 @@ NEXT_PUBLIC_MODERN_ADMIN_UI=0
 NEXT_PUBLIC_ENABLE_DEBUG=false
 ```
 
+### **Integrações do Google Analytics 4**
+```bash
+# Identificação da propriedade
+GA4_PROPERTY_ID=
+
+# Credenciais via service account
+GA4_SA_EMAIL=
+GA4_SA_KEY_BASE64=
+
+# Alternativa OAuth 2.0
+GA4_CLIENT_ID=
+GA4_CLIENT_SECRET=
+GA4_REFRESH_TOKEN=
+```
+> 💡 O campo `GA4_SA_KEY_BASE64` aceita tanto o JSON da chave (será convertido automaticamente)
+> quanto o conteúdo já codificado em Base64. Os campos legados `GOOGLE_APPLICATION_CREDENTIALS_JSON`
+> e `GA_OAUTH_*` continuam aceitos apenas como fallback.
+
 ## ⚠️ Regras e Boas Práticas
 
 ### **✅ Permitido**

--- a/web/src/app/admin/integrations/keys/page.tsx
+++ b/web/src/app/admin/integrations/keys/page.tsx
@@ -9,10 +9,11 @@ export default function AdminIntegrationKeysPage() {
   const [form, setForm] = useState<Record<string, string>>({
     OPENAI_API_KEY: '',
     GA4_PROPERTY_ID: '',
-    GOOGLE_APPLICATION_CREDENTIALS_JSON: '',
-    GA_OAUTH_CLIENT_ID: '',
-    GA_OAUTH_CLIENT_SECRET: '',
-    GA_OAUTH_REFRESH_TOKEN: '',
+    GA4_SA_EMAIL: '',
+    GA4_SA_KEY_BASE64: '',
+    GA4_CLIENT_ID: '',
+    GA4_CLIENT_SECRET: '',
+    GA4_REFRESH_TOKEN: '',
   });
   const [status, setStatus] = useState<'idle' | 'loading' | 'saved' | 'error'>('idle');
   const [error, setError] = useState<string | null>(null);
@@ -40,13 +41,87 @@ export default function AdminIntegrationKeysPage() {
     }
   }
 
-  const fields: Array<{ key: string; label: string; textarea?: boolean }> = [
+  function extractServiceAccountEmail(raw: string): string | undefined {
+    const value = raw.trim();
+    if (!value) return undefined;
+    const tryParse = (str: string): unknown => {
+      try {
+        return JSON.parse(str);
+      } catch {
+        return null;
+      }
+    };
+    const fromJson = (jsonStr: string) => {
+      const parsed = tryParse(jsonStr);
+      if (parsed && typeof parsed === 'object') {
+        const record = parsed as Record<string, unknown>;
+        const email = record.client_email;
+        if (typeof email === 'string') {
+          return email;
+        }
+      }
+      return undefined;
+    };
+    if (value.startsWith('{')) {
+      return fromJson(value);
+    }
+    const decodeBase64 = (str: string): string | null => {
+      try {
+        if (typeof atob === 'function') {
+          return atob(str);
+        }
+      } catch {
+        // ignore and fallback
+      }
+      try {
+        const globalBuffer = (globalThis as any)?.Buffer as
+          | { from(input: string, encoding: string): { toString(encoding: string): string } }
+          | undefined;
+        if (globalBuffer) {
+          return globalBuffer.from(str, 'base64').toString('utf8');
+        }
+      } catch {
+        // ignore
+      }
+      return null;
+    };
+    const decoded = decodeBase64(value);
+    return decoded ? fromJson(decoded) ?? undefined : undefined;
+  }
+
+  function handleFieldChange(key: string, rawValue: string) {
+    setForm((prev) => {
+      const next = { ...prev, [key]: rawValue };
+      if (key === 'GA4_SA_KEY_BASE64') {
+        const currentEmail = next.GA4_SA_EMAIL?.trim();
+        if (!currentEmail) {
+          const email = extractServiceAccountEmail(rawValue);
+          if (email) {
+            next.GA4_SA_EMAIL = email;
+          }
+        }
+      }
+      return next;
+    });
+  }
+
+  const fields: Array<{ key: string; label: string; textarea?: boolean; description?: string }> = [
     { key: 'OPENAI_API_KEY', label: 'OpenAI API Key' },
     { key: 'GA4_PROPERTY_ID', label: 'GA4 Property ID' },
-    { key: 'GOOGLE_APPLICATION_CREDENTIALS_JSON', label: 'Google Service Account JSON', textarea: true },
-    { key: 'GA_OAUTH_CLIENT_ID', label: 'OAuth Client ID' },
-    { key: 'GA_OAUTH_CLIENT_SECRET', label: 'OAuth Client Secret' },
-    { key: 'GA_OAUTH_REFRESH_TOKEN', label: 'OAuth Refresh Token' },
+    {
+      key: 'GA4_SA_EMAIL',
+      label: 'GA4 Service Account Email',
+      description: 'Opcional se o JSON/base64 contiver client_email',
+    },
+    {
+      key: 'GA4_SA_KEY_BASE64',
+      label: 'GA4 Service Account Key (JSON ou Base64)',
+      textarea: true,
+      description: 'Aceita o conteúdo JSON completo ou o valor já em Base64',
+    },
+    { key: 'GA4_CLIENT_ID', label: 'OAuth Client ID' },
+    { key: 'GA4_CLIENT_SECRET', label: 'OAuth Client Secret' },
+    { key: 'GA4_REFRESH_TOKEN', label: 'OAuth Refresh Token' },
   ];
 
   return (
@@ -66,10 +141,19 @@ export default function AdminIntegrationKeysPage() {
         {fields.map((f) => (
           <div key={f.key} className="space-y-1">
             <label className="text-sm opacity-70">{f.label}</label>
+            {f.description && <p className="text-xs opacity-60">{f.description}</p>}
             {f.textarea ? (
-              <textarea className="w-full h-28 p-2 rounded bg-black/30 border border-white/10 text-sm" placeholder={present[f.key] ? '•••••• (definido)' : ''} onChange={(e) => setForm((s) => ({ ...s, [f.key]: e.target.value }))} />
+              <textarea
+                className="w-full h-28 p-2 rounded bg-black/30 border border-white/10 text-sm"
+                placeholder={present[f.key] ? '•••••• (definido)' : ''}
+                onChange={(e) => handleFieldChange(f.key, e.target.value)}
+              />
             ) : (
-              <input className="w-full p-2 rounded bg-black/30 border border-white/10 text-sm" placeholder={present[f.key] ? '•••••• (definido)' : ''} onChange={(e) => setForm((s) => ({ ...s, [f.key]: e.target.value }))} />
+              <input
+                className="w-full p-2 rounded bg-black/30 border border-white/10 text-sm"
+                placeholder={present[f.key] ? '•••••• (definido)' : ''}
+                onChange={(e) => handleFieldChange(f.key, e.target.value)}
+              />
             )}
           </div>
         ))}

--- a/web/src/app/api/integrations/secrets/route.ts
+++ b/web/src/app/api/integrations/secrets/route.ts
@@ -17,7 +17,10 @@ export async function POST(req: NextRequest) {
   try {
     const body = (await req.json()) as Record<string, string | undefined>;
     const current = loadSecrets();
-    const merged = { ...current, ...body };
+    const sanitized = Object.fromEntries(
+      Object.entries(body).map(([key, value]) => [key, typeof value === 'string' ? value : undefined])
+    );
+    const merged = { ...current, ...sanitized } as Parameters<typeof saveSecretsLocal>[0];
     saveSecretsLocal(merged);
     return NextResponse.json({ ok: true });
   } catch (e: any) {

--- a/web/src/app/api/integrations/status/route.ts
+++ b/web/src/app/api/integrations/status/route.ts
@@ -5,9 +5,12 @@ import { loadSecrets } from '@/integrations/secrets';
 export async function GET() {
   // Não expõe segredos; apenas flags de disponibilidade
   const secrets = loadSecrets();
-  const ga4Present = Boolean(
-    integrations.has.ga4 || secrets.GA4_PROPERTY_ID
+  const ga4FromSecrets = Boolean(
+    secrets.GA4_PROPERTY_ID &&
+      ((secrets.GA4_SA_EMAIL && secrets.GA4_SA_KEY_BASE64) ||
+        (secrets.GA4_CLIENT_ID && secrets.GA4_CLIENT_SECRET && secrets.GA4_REFRESH_TOKEN))
   );
+  const ga4Present = Boolean(integrations.has.ga4 || ga4FromSecrets);
   const openaiPresent = Boolean(
     integrations.has.openai || secrets.OPENAI_API_KEY
   );

--- a/web/src/integrations/env.ts
+++ b/web/src/integrations/env.ts
@@ -9,13 +9,100 @@ const EnvSchema = z.object({
 
   // Analytics (GA4)
   GA4_PROPERTY_ID: z.string().optional(),
+  GA4_SA_EMAIL: z.string().optional(),
+  GA4_SA_KEY_BASE64: z.string().optional(),
+  GA4_CLIENT_ID: z.string().optional(),
+  GA4_CLIENT_SECRET: z.string().optional(),
+  GA4_REFRESH_TOKEN: z.string().optional(),
+
+  // Suporte legados
   GOOGLE_APPLICATION_CREDENTIALS_JSON: z.string().optional(),
   GA_OAUTH_CLIENT_ID: z.string().optional(),
   GA_OAUTH_CLIENT_SECRET: z.string().optional(),
   GA_OAUTH_REFRESH_TOKEN: z.string().optional(),
 });
 
-export type IntegrationsEnv = z.infer<typeof EnvSchema>;
+type RawIntegrationsEnv = z.infer<typeof EnvSchema>;
+
+export type IntegrationsEnv = {
+  OPENAI_API_KEY?: string;
+  AI_ASSISTANT_ENABLED?: 'true' | 'false';
+  AI_DRY_RUN?: 'true' | 'false';
+  GA4_PROPERTY_ID?: string;
+  GA4_SA_EMAIL?: string;
+  GA4_SA_KEY_BASE64?: string;
+  GA4_CLIENT_ID?: string;
+  GA4_CLIENT_SECRET?: string;
+  GA4_REFRESH_TOKEN?: string;
+};
+
+type ServiceAccountInfo = {
+  email?: string;
+  keyBase64?: string;
+};
+
+function parseServiceAccount(input?: string): ServiceAccountInfo {
+  const value = input?.trim();
+  if (!value) return {};
+
+  const fromJson = (jsonStr: string): ServiceAccountInfo | null => {
+    try {
+      const parsed = JSON.parse(jsonStr);
+      if (parsed && typeof parsed === 'object') {
+        return {
+          email:
+            typeof (parsed as { client_email?: unknown }).client_email === 'string'
+              ? (parsed as { client_email?: string }).client_email
+              : undefined,
+          keyBase64: Buffer.from(jsonStr, 'utf8').toString('base64'),
+        };
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  };
+
+  if (value.startsWith('{')) {
+    const info = fromJson(value);
+    if (info) return info;
+  }
+
+  try {
+    const decoded = Buffer.from(value, 'base64').toString('utf8');
+    const info = fromJson(decoded);
+    if (info) {
+      return {
+        email: info.email,
+        keyBase64: Buffer.from(decoded, 'utf8').toString('base64'),
+      };
+    }
+    if (decoded) {
+      return { keyBase64: value };
+    }
+  } catch {
+    // ignore
+  }
+
+  return { keyBase64: Buffer.from(value, 'utf8').toString('base64') };
+}
+
+function normalizeEnv(env: RawIntegrationsEnv): IntegrationsEnv {
+  const saFromNew = parseServiceAccount(env.GA4_SA_KEY_BASE64);
+  const saFromLegacy = parseServiceAccount(env.GOOGLE_APPLICATION_CREDENTIALS_JSON);
+
+  return {
+    OPENAI_API_KEY: env.OPENAI_API_KEY?.trim() || undefined,
+    AI_ASSISTANT_ENABLED: env.AI_ASSISTANT_ENABLED,
+    AI_DRY_RUN: env.AI_DRY_RUN,
+    GA4_PROPERTY_ID: env.GA4_PROPERTY_ID?.trim() || undefined,
+    GA4_SA_EMAIL: env.GA4_SA_EMAIL?.trim() || saFromNew.email || saFromLegacy.email,
+    GA4_SA_KEY_BASE64: saFromNew.keyBase64 || saFromLegacy.keyBase64,
+    GA4_CLIENT_ID: env.GA4_CLIENT_ID?.trim() || env.GA_OAUTH_CLIENT_ID?.trim() || undefined,
+    GA4_CLIENT_SECRET: env.GA4_CLIENT_SECRET?.trim() || env.GA_OAUTH_CLIENT_SECRET?.trim() || undefined,
+    GA4_REFRESH_TOKEN: env.GA4_REFRESH_TOKEN?.trim() || env.GA_OAUTH_REFRESH_TOKEN?.trim() || undefined,
+  };
+}
 
 function readEnv(): IntegrationsEnv {
   // Usa apenas process.env (server). Não exporte para cliente.
@@ -26,7 +113,7 @@ function readEnv(): IntegrationsEnv {
     console.warn('[integrations/env] variáveis ausentes ou inválidas', parsed.error?.errors);
     return {} as IntegrationsEnv;
   }
-  return parsed.data;
+  return normalizeEnv(parsed.data);
 }
 
 export const integrationsEnv = readEnv();
@@ -38,10 +125,7 @@ export function hasOpenAI(): boolean {
 export function hasGA4(): boolean {
   return Boolean(
     integrationsEnv.GA4_PROPERTY_ID &&
-      (integrationsEnv.GOOGLE_APPLICATION_CREDENTIALS_JSON ||
-        (integrationsEnv.GA_OAUTH_CLIENT_ID && integrationsEnv.GA_OAUTH_CLIENT_SECRET && integrationsEnv.GA_OAUTH_REFRESH_TOKEN))
+      ((integrationsEnv.GA4_SA_EMAIL && integrationsEnv.GA4_SA_KEY_BASE64) ||
+        (integrationsEnv.GA4_CLIENT_ID && integrationsEnv.GA4_CLIENT_SECRET && integrationsEnv.GA4_REFRESH_TOKEN))
   );
 }
-
-
-

--- a/web/src/integrations/secrets.ts
+++ b/web/src/integrations/secrets.ts
@@ -1,6 +1,7 @@
 import './server-only';
 import crypto from 'crypto';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 // Apenas para DEV/LOCAL: armazena chaves cifradas em arquivo.
@@ -11,7 +12,7 @@ const secretsFile = path.join(process.cwd(), 'secrets.local.enc.json');
 
 function getKeyMaterial(): Buffer {
   // Usa uma chave derivada do hostname de desenvolvimento (melhor do que nada para local)
-  const seed = process.env.SECRETS_LOCAL_KEY || require('os').hostname();
+  const seed = process.env.SECRETS_LOCAL_KEY || os.hostname();
   return crypto.createHash('sha256').update(seed).digest();
 }
 
@@ -40,40 +41,131 @@ function decryptJson(b64: string): any {
 export type StoredSecrets = {
   OPENAI_API_KEY?: string;
   GA4_PROPERTY_ID?: string;
+  GA4_SA_EMAIL?: string;
+  GA4_SA_KEY_BASE64?: string;
+  GA4_CLIENT_ID?: string;
+  GA4_CLIENT_SECRET?: string;
+  GA4_REFRESH_TOKEN?: string;
+};
+
+type LegacySecrets = {
   GOOGLE_APPLICATION_CREDENTIALS_JSON?: string;
   GA_OAUTH_CLIENT_ID?: string;
   GA_OAUTH_CLIENT_SECRET?: string;
   GA_OAUTH_REFRESH_TOKEN?: string;
 };
 
+type RawSecrets = Partial<StoredSecrets & LegacySecrets>;
+
+type ServiceAccountInfo = {
+  email?: string;
+  keyBase64?: string;
+};
+
+const clean = (value?: string): string | undefined => {
+  if (value === undefined) return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+function parseServiceAccount(input?: string): ServiceAccountInfo {
+  const value = clean(input);
+  if (!value) return {};
+
+  const fromJson = (jsonStr: string): ServiceAccountInfo | null => {
+    try {
+      const parsed = JSON.parse(jsonStr);
+      if (parsed && typeof parsed === 'object') {
+        return {
+          email:
+            typeof (parsed as { client_email?: unknown }).client_email === 'string'
+              ? (parsed as { client_email?: string }).client_email
+              : undefined,
+          keyBase64: Buffer.from(jsonStr, 'utf8').toString('base64'),
+        };
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  };
+
+  if (value.startsWith('{')) {
+    const info = fromJson(value);
+    if (info) return info;
+  }
+
+  try {
+    const decoded = Buffer.from(value, 'base64').toString('utf8');
+    const info = fromJson(decoded);
+    if (info) {
+      return {
+        email: info.email,
+        keyBase64: Buffer.from(decoded, 'utf8').toString('base64'),
+      };
+    }
+    if (decoded) {
+      return { keyBase64: value };
+    }
+  } catch {
+    // ignore
+  }
+
+  return { keyBase64: Buffer.from(value, 'utf8').toString('base64') };
+}
+
+function normalizeSecrets(data: RawSecrets): StoredSecrets {
+  const saFromNew = parseServiceAccount(data.GA4_SA_KEY_BASE64);
+  const saFromLegacy = parseServiceAccount(data.GOOGLE_APPLICATION_CREDENTIALS_JSON);
+  const keyBase64 = clean(saFromNew.keyBase64) || clean(saFromLegacy.keyBase64);
+
+  return {
+    OPENAI_API_KEY: clean(data.OPENAI_API_KEY),
+    GA4_PROPERTY_ID: clean(data.GA4_PROPERTY_ID),
+    GA4_SA_EMAIL: clean(data.GA4_SA_EMAIL) || clean(saFromNew.email) || clean(saFromLegacy.email),
+    GA4_SA_KEY_BASE64: keyBase64,
+    GA4_CLIENT_ID: clean(data.GA4_CLIENT_ID) || clean(data.GA_OAUTH_CLIENT_ID),
+    GA4_CLIENT_SECRET: clean(data.GA4_CLIENT_SECRET) || clean(data.GA_OAUTH_CLIENT_SECRET),
+    GA4_REFRESH_TOKEN: clean(data.GA4_REFRESH_TOKEN) || clean(data.GA_OAUTH_REFRESH_TOKEN),
+  };
+}
+
 export function loadSecrets(): StoredSecrets {
   if (isProd) {
     // Em produção, leitura direta de env (sem arquivo)
-    return {
+    const raw: RawSecrets = {
       OPENAI_API_KEY: process.env.OPENAI_API_KEY,
       GA4_PROPERTY_ID: process.env.GA4_PROPERTY_ID,
+      GA4_SA_EMAIL: process.env.GA4_SA_EMAIL,
+      GA4_SA_KEY_BASE64: process.env.GA4_SA_KEY_BASE64,
+      GA4_CLIENT_ID: process.env.GA4_CLIENT_ID,
+      GA4_CLIENT_SECRET: process.env.GA4_CLIENT_SECRET,
+      GA4_REFRESH_TOKEN: process.env.GA4_REFRESH_TOKEN,
       GOOGLE_APPLICATION_CREDENTIALS_JSON: process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON,
       GA_OAUTH_CLIENT_ID: process.env.GA_OAUTH_CLIENT_ID,
       GA_OAUTH_CLIENT_SECRET: process.env.GA_OAUTH_CLIENT_SECRET,
       GA_OAUTH_REFRESH_TOKEN: process.env.GA_OAUTH_REFRESH_TOKEN,
     };
+    return normalizeSecrets(raw);
   }
   try {
     if (!fs.existsSync(secretsFile)) return {};
     const b64 = fs.readFileSync(secretsFile, 'utf8');
-    return decryptJson(b64) as StoredSecrets;
+    const raw = decryptJson(b64) as RawSecrets;
+    return normalizeSecrets(raw);
   } catch {
     return {};
   }
 }
 
-export function saveSecretsLocal(data: StoredSecrets) {
+export function saveSecretsLocal(data: RawSecrets) {
   if (isProd) {
     throw new Error('Saving secrets is disabled in production');
   }
-  const b64 = encryptJson(data);
+  const normalized = normalizeSecrets(data);
+  const serializable = Object.fromEntries(
+    Object.entries(normalized).filter(([, value]) => value !== undefined)
+  );
+  const b64 = encryptJson(serializable);
   fs.writeFileSync(secretsFile, b64, 'utf8');
 }
-
-
-


### PR DESCRIPTION
## Summary
- normalize GA4 environment variables to share the same field names expected by the GA4 client while keeping legacy fallbacks
- update secret storage APIs and the admin credentials form to read and save the new GA4 service account and OAuth fields, auto-filling the email when possible
- document the refreshed GA4 configuration variables for local and production environments

## Testing
- npm run lint *(fails: existing lint errors in unrelated files and legacy patterns such as require usage)*

------
https://chatgpt.com/codex/tasks/task_e_68dac857bcb483298d18e54a40e3391d